### PR TITLE
Remove erroneous trailing comma in CH3 test

### DIFF
--- a/apu/channel_3/channel_3_restart_delay.asm
+++ b/apu/channel_3/channel_3_restart_delay.asm
@@ -19,11 +19,11 @@ SubTest: MACRO
     cpl
     ld hl, $ff31
     ldh [rNR52], a
-    
+
     REPT 15
     ldi [hl], a
     ENDR
-    
+
     ld hl, rPCM34
     ldh [rNR30], a
     ld a, $de
@@ -32,11 +32,11 @@ SubTest: MACRO
     ldh [rNR32], a
     ld a, $87
     ldh [rNR34], a
-    
+
     nops $280 ; Let the sound play for a while
-    ldh [rNR34], a ; Restart the sound and see what happens    
+    ldh [rNR34], a ; Restart the sound and see what happens
     nops \1
-    
+
     ld a, [hl]
     call StoreResult
     ENDM
@@ -45,26 +45,25 @@ RunTest:
     ld a, 1
     ldh [rKEY1], a
     stop
-    
+
     ld de, $c000
 
-    ; Wave length is $2000 T-Cycles, so each sample is $100 M-Cycles long    
-    SubTest $0, 
-    SubTest $1, 
+    ; Wave length is $2000 T-Cycles, so each sample is $100 M-Cycles long
+    SubTest $0
+    SubTest $1
     SubTest $0FE
     SubTest $0FF
     SubTest $100
     SubTest $101
     SubTest $102
     SubTest $103
-        
+
     ret
-    
-    
+
+
 StoreResult::
     ld [de], a
     inc de
     ret
-    
+
     CGB_MODE
-    


### PR DESCRIPTION
This broke under RGBDS 0.4.1