### PR TITLE
Reinstate titles in ROMs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ all: $(TARGETS)
 	
 %.gb: %.o
 	rgblink -o $@ -n $(@:%.gb=%.sym) $<
-	rgbfix -jv $@
+	rgbfix -jv -t $(shell echo $(notdir $(@:%.gb=%)) | tail -c 15) $@
 	
 clean:
 	@rm -f $(TARGETS) $(TARGETS:%.gb=%.sym) $(TARGETS:%.gb=%.o)


### PR DESCRIPTION
This was disabled in 277f7f7bf1835fea5cdffb4fedbf9517ff1f6074 due to a RGBFIX bug, which was fixed in RGBDS 0.5.0.